### PR TITLE
update sklearn package name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,6 @@ setuptools.setup(
         'pandas',
         'numpy',
         'statsmodels',
-        'sklearn'
+        'scikit-learn'
     ],
 )


### PR DESCRIPTION
got error when installing the package "The 'sklearn' PyPI package is deprecated, use 'scikit-learn' rather than 'sklearn' for pip commands"