### PR TITLE
sklearn -> scikit-learn

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 pandas
 numpy
 statsmodels
-sklearn
+scikit-learn

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,6 @@ setuptools.setup(
         'pandas',
         'numpy',
         'statsmodels',
-        'sklearn'
+        'scikit-learn'
     ],
 )


### PR DESCRIPTION
The sklearn package is now deprecated. If you try to install imputena in a new virtual env it gives errors because it tries to install the deprecated package sklearn. Guidance is [here](https://pypi.org/project/sklearn/): the references to sklearn in the docs/requirements.txt and setup.py files just have to be replaced with scikit-learn. The calls in python files like 'from sklearn import ...' stay the same.